### PR TITLE
Add Vale Config file

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = Google, Vale, write-good
+
+Vale.Spelling = YES


### PR DESCRIPTION
Signed-off-by: Anas Abou Allaban <allabana@amazon.com>

*Issue*

[ros-security/aws-oncall#32](https://github.com/ros-security/aws-oncall/issues/32)

*Description of changes:*

Add `.vale.ini` config file for the vale GH action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
